### PR TITLE
upgrade restify 2.8.1 to 2.8.2 breaks socket.io 1.x integration

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -185,6 +185,7 @@ function Server(options) {
     this.routes = {};
     this.secure = false;
     this.versions = options.versions || options.version || [];
+    this.socketio = options.socketio || false;
 
     var fmt = mergeFormatters(options.formatters);
     this.acceptable = fmt.acceptable;
@@ -248,6 +249,8 @@ function Server(options) {
 
     this.server.on('request', function onRequest(req, res) {
         self.emit('request', req, res);
+        if ( options.socketio && /^\/socket\.io.*/.test(req.url))
+             return;
 
         self._setupRequest(req, res);
         self._handle(req, res);


### PR DESCRIPTION
When I updated to the latest restify I got the following error all of a sudden:

Error: Can't set headers after they are sent.
  at ServerResponse.OutgoingMessage.setHeader (http.js:689:11)
...

I can get around the problem by not having socket.io use the restify server instance and listen on its own port instead of sharing it.

So normally I'd use:
server = restify.createServer()
socketServer = io.listen( server )
server.listen( 8080 )

Fixing requires either sticking with 2.8.1 or choosing a different port/listener for socket.io:
server = restify.createServer()
socketServer = io.listen( 8081 )
server.listen( 8080 )

All this worked flawless before the minor update. I'm trying to figure out if this is an issue with socket.io , restify or something in how my code uses either. Since the minor update of restify seems to have caused it I'm starting my search here. Any help would be appreciated.

socket.io: 1.0.6
restify: 2.8.2