### PR TITLE
Add 'server.route' alias for multiple methods

### DIFF
--- a/docs/index.restdown
+++ b/docs/index.restdown
@@ -257,6 +257,22 @@ Routes can also accept more than one handler function. For instance:
         }
     );
 
+### Multiple Methods
+
+An alias can be defined to use different methods on the same path.
+To prevent repetition you can use:
+
+    var route = server.route('/foo/:id');
+
+    route.get(function(req, res, next) {
+      return fs.createReadStream('README.md')).pipe(res);
+    });
+
+    route.post(function(req, res, next) {
+      console.log('Read Only')
+      return next;
+    });
+
 ### Hypermedia
 
 If a parameterized route was defined with a string (not a regex), you can render it from other places in the server. This is useful to have HTTP responses that link to other resources, without having to hardcode URLs throughout the codebase. Both path and query strings parameters get URL encoded appropriately.
@@ -999,8 +1015,8 @@ is expected that you are going to map it to a route, as below:
       default: 'index.html'
     }));
 
-The above `route` and `directory` combination will serve a file located in  
-`./documentation/v1/docs/current/index.html` when you attempt to hit 
+The above `route` and `directory` combination will serve a file located in
+`./documentation/v1/docs/current/index.html` when you attempt to hit
 `http://localhost:8080/docs/current/`.
 
 The plugin will enforce that all files under `directory` are served. The

--- a/lib/plugins/static.js
+++ b/lib/plugins/static.js
@@ -93,8 +93,9 @@ function serveStatic(opts) {
     }
 
     function serve(req, res, next) {
-        var file = path.join(opts.directory,
-            decodeURIComponent(req.path()));
+        var file = path.join(opts.directory, decodeURIComponent(req.getPath()));
+        var pattern = req.route.path.source.match(/(\/[a-zA-Z0-9]+)/);
+        file = file.replace(pattern[0], '');
 
         if (req.method !== 'GET' && req.method !== 'HEAD') {
             next(new MethodNotAllowedError(req.method));
@@ -132,7 +133,7 @@ function serveStatic(opts) {
 
     }
 
-    return (serve);
+    return serve;
 }
 
 module.exports = serveStatic;

--- a/lib/plugins/static.js
+++ b/lib/plugins/static.js
@@ -68,7 +68,8 @@ function serveStatic(opts) {
 
     function serveNormal(file, req, res, next) {
         fs.stat(file, function (err, stats) {
-            if (!err && stats.isDirectory() && opts.default) {
+            var last = req.getPath().split('').pop();
+            if (!err && stats.isDirectory() && opts.default && last === '/') {
                 // Serve an index.html page or similar
                 file = path.join(file, opts.default);
                 fs.stat(file, function (dirErr, dirStats) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -336,7 +336,7 @@ Server.prototype.close = function close(callback) {
  * @param {Object} options the URL to handle, at minimum.
  * @return {Route} the newly created route.
  */
-[
+var methods = [
     'del',
     'get',
     'head',
@@ -344,64 +344,85 @@ Server.prototype.close = function close(callback) {
     'post',
     'put',
     'patch'
-].forEach(function (method) {
-        Server.prototype[method] = function (opts) {
-            if (opts instanceof RegExp || typeof (opts) === 'string') {
-                opts = {
-                    path: opts
-                };
-            } else if (typeof (opts) === 'object') {
-                opts = shallowCopy(opts);
-            } else {
-                throw new TypeError('path (string) required');
+];
+
+methods.forEach(function (method) {
+    Server.prototype[method] = function (opts) {
+        if (opts instanceof RegExp || typeof (opts) === 'string') {
+            opts = {
+                path: opts
+            };
+        } else if (typeof (opts) === 'object') {
+            opts = shallowCopy(opts);
+        } else {
+            throw new TypeError('path (string) required');
+        }
+
+        if (arguments.length < 2)
+            throw new TypeError('handler (function) required');
+
+        var chain = [];
+        var route;
+        var self = this;
+
+        function addHandler(h) {
+            assert.func(h, 'handler');
+
+            chain.push(h);
+        }
+
+        if (method === 'del')
+            method = 'DELETE';
+        if (method === 'opts')
+            method = 'OPTIONS';
+        opts.method = method.toUpperCase();
+        opts.versions = opts.versions || opts.version || self.versions;
+        if (!Array.isArray(opts.versions))
+            opts.versions = [opts.versions];
+
+        if (!opts.name) {
+            opts.name = method + '-' + (opts.path || opts.url);
+            if (opts.versions.length > 0) {
+                opts.name += '-' + opts.versions.join('--');
             }
 
-            if (arguments.length < 2)
-                throw new TypeError('handler (function) required');
-
-            var chain = [];
-            var route;
-            var self = this;
-
-            function addHandler(h) {
-                assert.func(h, 'handler');
-
-                chain.push(h);
-            }
-
-            if (method === 'del')
-                method = 'DELETE';
-            if (method === 'opts')
-                method = 'OPTIONS';
-            opts.method = method.toUpperCase();
-            opts.versions = opts.versions || opts.version || self.versions;
-            if (!Array.isArray(opts.versions))
-                opts.versions = [opts.versions];
-
-            if (!opts.name) {
-                opts.name = method + '-' + (opts.path || opts.url);
-                if (opts.versions.length > 0) {
-                    opts.name += '-' + opts.versions.join('--');
-                }
-
-                opts.name = opts.name.replace(/\W/g, '').toLowerCase();
-                if (this.router.mounts[opts.name]) // GH-401
-                    opts.name += uuid.v4().substr(0, 7);
-            } else {
-                opts.name = opts.name.replace(/\W/g, '').toLowerCase();
-            }
+            opts.name = opts.name.replace(/\W/g, '').toLowerCase();
+            if (this.router.mounts[opts.name]) // GH-401
+                opts.name += uuid.v4().substr(0, 7);
+        } else {
+            opts.name = opts.name.replace(/\W/g, '').toLowerCase();
+        }
 
 
-            if (!(route = this.router.mount(opts)))
-                return (false);
+        if (!(route = this.router.mount(opts)))
+            return (false);
 
-            this.chain.forEach(addHandler);
-            argumentsToChain(arguments, 1).forEach(addHandler);
-            this.routes[route] = chain;
+        this.chain.forEach(addHandler);
+        argumentsToChain(arguments, 1).forEach(addHandler);
+        this.routes[route] = chain;
 
-            return (route);
-        };
-    });
+        return (route);
+    };
+});
+
+
+/**
+ * Defines an alias to declare multiple routing methods for the same address.
+ *
+ * @param  {String} path the pattern to match the URL
+ * @return {Object}      reference to attach the methods
+ */
+Server.prototype.route = function route(path) {
+    var route = Object.create(null);
+    methods.forEach(function (method) {
+        route[method] = function(/** arguments **/) {
+            var args = [path];
+            args.push.apply(args, arguments);
+            this[method].apply(this, args)
+        }.bind(this);
+    }, this);
+    return route;
+};
 
 
 /**


### PR DESCRIPTION
A route can be defined which delegates to the proper methods, preventing repetitive declaration of the path. In addition got the static plugin a modification: the directory path is just relative and decoupled from the actual route path without getting prefixed.