### PR TITLE
Adding before event as a general solution to 2.8.2 breaking socket.io 

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -248,9 +248,15 @@ function Server(options) {
 
     this.server.on('request', function onRequest(req, res) {
         self.emit('request', req, res);
+        var handleRequest = function() {
+            self._setupRequest(req, res);
+            self._handle(req, res);
+            handleRequest = function(){};
+        };
 
-        self._setupRequest(req, res);
-        self._handle(req, res);
+        if (false === self.emit('before', req, res, handleRequest)) {
+            handleRequest();
+        }
     });
 
     this.__defineGetter__('maxHeadersCount', function () {


### PR DESCRIPTION
Went ahead and created what I was suggesting in #669 

For some reason 'request' was being emitted without the handleRequest callback.  Seems like it was being emitted from outside restify maybe?

Instead, I just added a before event to match the 'after' that already exists.

Very limited testing...