### PR TITLE
Fix throttle using and/or reporting incorrect rate (if overrides present) in response

### DIFF
--- a/lib/plugins/throttle.js
+++ b/lib/plugins/throttle.js
@@ -190,13 +190,14 @@ function throttle(options) {
     if (!xor(options.ip, options.xff, options.username))
         throw new Error('(ip ^ username ^ xff)');
 
-    var burst = options.burst;
-    var rate = options.rate;
     var table = options.tokensTable ||
         new TokenTable({size: options.maxKeys});
 
     function rateLimit(req, res, next) {
         var attr;
+        var burst = options.burst;
+        var rate = options.rate;
+
         if (options.ip) {
             attr = req.connection.remoteAddress;
         } else if (options.xff) {
@@ -247,8 +248,6 @@ function throttle(options) {
                 user: req.username || '?'
             }, 'Throttling');
 
-
-            // Until https://github.com/joyent/node/pull/2371 is in
             var msg = sprintf(MESSAGE, rate);
             return (next(new TooManyRequestsError(msg)));
         }

--- a/test/throttle.test.js
+++ b/test/throttle.test.js
@@ -23,7 +23,7 @@ var SERVER;
 var USERNAME = uuid();
 var PASSWORD = uuid();
 
-
+var errorMessage = 'Error message should include rate 0.5 r/s. Received: ';
 ///--- Tests
 
 
@@ -90,7 +90,8 @@ test('throttled', function (t) {
     CLIENT.get('/test/throttleMe', function (err, _, res) {
         t.ok(err);
         t.equal(err.statusCode, 429);
-        t.ok(err && err.message && err.message.indexOf('0.5 r/s') !== -1, 'Error message should include correct request rate 0.5 r/s. Received: ' + (err && err.message));
+        t.ok(err && err.message && err.message.indexOf('0.5 r/s') !== -1,
+            errorMessage + (err && err.message));
         t.equal(res.statusCode, 429);
         setTimeout(function () {
             t.end();
@@ -126,11 +127,12 @@ test('override limited (not throttled)', function (t) {
 });
 
 test('throttled after limited override', function (t) {
-    CLIENT.get('/test/throttleMe', function (err, _, res) {
+    CLIENT.get('/test/throttleMe', function () {
     CLIENT.get('/test/throttleMe', function (err, _, res) {
         t.ok(err);
         t.equal(res.statusCode, 429);
-        t.ok(err && err.message && err.message.indexOf('0.5 r/s') !== -1, 'Error message should include correct request rate 0.5 r/s. Received: ' + (err && err.message));
+        t.ok(err && err.message && err.message.indexOf('0.5 r/s') !== -1,
+            errorMessage + (err && err.message));
         t.end();
     });
     });
@@ -155,11 +157,12 @@ test('override unlimited (not throttled)', function (t) {
 });
 
 test('throttled after unlimited override', function (t) {
-    CLIENT.get('/test/throttleMe', function (err, _, res) {
+    CLIENT.get('/test/throttleMe', function () {
     CLIENT.get('/test/throttleMe', function (err, _, res) {
         t.ok(err);
         t.equal(res.statusCode, 429);
-        t.ok(err && err.message && err.message.indexOf('0.5 r/s') !== -1, 'Error message should include correct request rate 0.5 r/s. Received: ' + (err && err.message));
+        t.ok(err && err.message && err.message.indexOf('0.5 r/s') !== -1,
+            errorMessage + (err && err.message));
         t.end();
     });
     });

--- a/test/throttle.test.js
+++ b/test/throttle.test.js
@@ -90,7 +90,7 @@ test('throttled', function (t) {
     CLIENT.get('/test/throttleMe', function (err, _, res) {
         t.ok(err);
         t.equal(err.statusCode, 429);
-        t.ok(err.message);
+        t.ok(err && err.message && err.message.indexOf('0.5 r/s') !== -1, 'Error message should include correct request rate 0.5 r/s. Received: ' + (err && err.message));
         t.equal(res.statusCode, 429);
         setTimeout(function () {
             t.end();
@@ -125,6 +125,17 @@ test('override limited (not throttled)', function (t) {
     });
 });
 
+test('throttled after limited override', function (t) {
+    CLIENT.get('/test/throttleMe', function (err, _, res) {
+    CLIENT.get('/test/throttleMe', function (err, _, res) {
+        t.ok(err);
+        t.equal(res.statusCode, 429);
+        t.ok(err && err.message && err.message.indexOf('0.5 r/s') !== -1, 'Error message should include correct request rate 0.5 r/s. Received: ' + (err && err.message));
+        t.end();
+    });
+    });
+});
+
 
 test('override unlimited', function (t) {
     CLIENT.get('/test/admin', function (err, _, res) {
@@ -143,6 +154,16 @@ test('override unlimited (not throttled)', function (t) {
     });
 });
 
+test('throttled after unlimited override', function (t) {
+    CLIENT.get('/test/throttleMe', function (err, _, res) {
+    CLIENT.get('/test/throttleMe', function (err, _, res) {
+        t.ok(err);
+        t.equal(res.statusCode, 429);
+        t.ok(err && err.message && err.message.indexOf('0.5 r/s') !== -1, 'Error message should include correct request rate 0.5 r/s. Received: ' + (err && err.message));
+        t.end();
+    });
+    });
+});
 
 test('shutdown', function (t) {
     SERVER.close(function () {


### PR DESCRIPTION
Throttle could use an incorrect default rate if a request utilizing
an override occurred as the first request.

Throttle could also report the wrong rate in the response message if a
request utilizing an override has occurred since start.

Also removed the outdated comment.