### PR TITLE
Support multiple response header values.

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -129,7 +129,12 @@ Response.prototype.header = function header(name, value) {
 
     var current = this.getHeader(name);
     if (current) {
-        value = [current, value];
+        if (Array.isArray(current)) {
+            current.push(value);
+            value = current;
+        } else {
+            value = [current, value];
+        }
     }
 
     this.setHeader(name, value);

--- a/lib/response.js
+++ b/lib/response.js
@@ -127,6 +127,11 @@ Response.prototype.header = function header(name, value) {
         value = sprintf(value, arg);
     }
 
+    var current = this.getHeader(name);
+    if (current) {
+        value = [current, value];
+    }
+
     this.setHeader(name, value);
     return (value);
 };

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1605,7 +1605,6 @@ test('explicitly sending a 403 with custom error', function (t) {
     });
 });
 
-
 test('explicitly sending a 403 on error', function (t) {
     SERVER.get('/', function (req, res, next) {
         res.send(403, new Error('bah!'));
@@ -1614,6 +1613,20 @@ test('explicitly sending a 403 on error', function (t) {
     CLIENT.get('/', function (err, _, res) {
         t.ok(err);
         t.equal(res.statusCode, 403);
+        t.end();
+    });
+});
+
+test('GH-693 sending multiple response header values', function (t) {
+    SERVER.get('/', function (req, res, next) {
+        res.link("/", "self");
+        res.link("/foo", "foo");
+        res.send(200, "root");
+    });
+
+    CLIENT.get('/', function (err, _, res) {
+        t.equal(res.statusCode, 200);
+        t.equal(res.headers['link'].split(',').length, 2);
         t.end();
     });
 });

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1621,12 +1621,13 @@ test('GH-693 sending multiple response header values', function (t) {
     SERVER.get('/', function (req, res, next) {
         res.link("/", "self");
         res.link("/foo", "foo");
+        res.link("/bar", "bar");
         res.send(200, "root");
     });
 
     CLIENT.get('/', function (err, _, res) {
         t.equal(res.statusCode, 200);
-        t.equal(res.headers['link'].split(',').length, 2);
+        t.equal(res.headers['link'].split(',').length, 3);
         t.end();
     });
 });


### PR DESCRIPTION
Multiple response headers will be stored as an array, and passed
to the Node.js `ServerResponse`.

See http://nodejs.org/api/http.html#http_response_setheader_name_value
and
https://github.com/joyent/node/issues/2750