### PR TITLE
Allows partial regex for named parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ examples/todoapp/node_modules
 *.tgz
 build
 docs/*.json
+/nbproject

--- a/lib/router.js
+++ b/lib/router.js
@@ -92,18 +92,17 @@ function compileURL(options) {
             var label = frag;
             var index = frag.indexOf('(');
             var subexp;
-            if(index === -1) {
-                subexp = '(' + (options.urlParamPattern ? options.urlParamPattern : '[^/]*') + ')';
+            if (index === -1) {
+                subexp = options.urlParamPattern ? options.urlParamPattern : '[^/]*';
             } else {
                 label = frag.substring(0, index);
-                subexp = frag.substring(index);
+                subexp = frag.substring(index+1, frag.length-1);
             }
-            pattern += subexp;
+            pattern += '(' + subexp + ')';
             params.push(label.slice(1));
         } else {
             pattern += frag;
         }
-
         return (true);
     });
 
@@ -173,10 +172,9 @@ Router.prototype.render = function render(routeName, params, query) {
     function pathItem(match, key) {
         if (params.hasOwnProperty(key) === false) {
             throw new Error('Route <' + routeName +
-                            '> is missing parameter <' +
-                            key + '>');
+                    '> is missing parameter <' +
+                    key + '>');
         }
-
         return ('/' + encodeURIComponent(params[key]));
     }
 
@@ -189,7 +187,7 @@ Router.prototype.render = function render(routeName, params, query) {
     if (!route)
         return (null);
 
-    var _url = route.spec.path.replace(/\/:([A-Za-z0-9_]+)(\([^\)]+\))?/g, pathItem);
+    var _url = route.spec.path.replace(/\/:([A-Za-z0-9_]+)(\([^\\]+\))?/g, pathItem);
     var items = Object.keys(query || {}).map(queryItem);
     var queryString = items.length > 0 ? ('?' + items.join('&')) : '';
     return (_url + queryString);
@@ -252,10 +250,10 @@ Router.prototype.mount = function mount(options) {
     this.mounts[route.name] = route;
 
     this.emit('mount',
-        route.method,
-        route.path,
-        route.types,
-        route.versions);
+            route.method,
+            route.path,
+            route.types,
+            route.versions);
 
     return (route.name);
 };
@@ -436,9 +434,9 @@ Router.prototype.find = function find(req, res, callback) {
     }
     if (versioned) {
         callback(new InvalidVersionError('%s is not supported by %s %s',
-            req.version() || '?',
-            req.method,
-            req.path()));
+                req.version() || '?',
+                req.method,
+                req.path()));
         return;
     }
 
@@ -459,7 +457,7 @@ Router.prototype.find = function find(req, res, callback) {
         var origin = req.headers['origin'];
 
         if (req.method !== 'OPTIONS' || !origin || !method ||
-            methods.indexOf(method) === -1) {
+                methods.indexOf(method) === -1) {
             return (false);
         }
         // Last, check request-headers
@@ -481,9 +479,9 @@ Router.prototype.find = function find(req, res, callback) {
             res.setHeader('Access-Control-Allow-Origin', '*');
         }
         res.setHeader('Access-Control-Allow-Methods',
-            methods.join(', '));
+                methods.join(', '));
         res.setHeader('Access-Control-Allow-Headers',
-            cors.ALLOW_HEADERS.join(', '));
+                cors.ALLOW_HEADERS.join(', '));
         res.setHeader('Access-Control-Max-Age', 3600);
 
         return (true);
@@ -496,11 +494,11 @@ Router.prototype.find = function find(req, res, callback) {
             res.methods = this.reverse[urls[i]].slice();
             res.setHeader('Allow', res.methods.join(', '));
             if (preflight(res.methods)) {
-                callback(null, { name: 'preflight' });
+                callback(null, {name: 'preflight'});
                 return;
             }
             var err = new MethodNotAllowedError('%s is not allowed',
-                req.method);
+                    req.method);
             callback(err);
             return;
         }

--- a/lib/router.js
+++ b/lib/router.js
@@ -175,15 +175,6 @@ Router.prototype.render = function render(routeName, params, query) {
             throw new Error('Route <' + routeName +
                             '> is missing parameter <' +
                             key + '>');
-        } else {
-            var index = match.indexOf('(');
-            if(index > 0) {
-                match = new RegExp(match.substring(index), 'g');
-                if(!match.test(params[key])) {
-                    throw new Error('Unvalid value <' + params[key] + '> ' +
-                            'for key <' + key + '>. Regular expression not matched');
-                }
-            }
         }
 
         return ('/' + encodeURIComponent(params[key]));

--- a/lib/router.js
+++ b/lib/router.js
@@ -89,12 +89,17 @@ function compileURL(options) {
 
         pattern += '\\/+';
         if (frag.charAt(0) === ':') {
-            if (options.urlParamPattern) {
-                pattern += '(' + options.urlParamPattern + ')';
+            var label = frag;
+            var index = frag.indexOf('(');
+            var subexp;
+            if(index === -1) {
+                subexp = '(' + (options.urlParamPattern ? options.urlParamPattern : '[^/]*') + ')';
             } else {
-                pattern += '([^/]*)';
+                label = frag.substring(0, index);
+                subexp = frag.substring(index);
             }
-            params.push(frag.slice(1));
+            pattern += subexp;
+            params.push(label.slice(1));
         } else {
             pattern += frag;
         }
@@ -170,6 +175,15 @@ Router.prototype.render = function render(routeName, params, query) {
             throw new Error('Route <' + routeName +
                             '> is missing parameter <' +
                             key + '>');
+        } else {
+            var index = match.indexOf('(');
+            if(index > 0) {
+                match = new RegExp(match.substring(index), 'g');
+                if(!match.test(params[key])) {
+                    throw new Error('Unvalid value <' + params[key] + '> ' +
+                            'for key <' + key + '>. Regular expression not matched');
+                }
+            }
         }
 
         return ('/' + encodeURIComponent(params[key]));
@@ -184,10 +198,9 @@ Router.prototype.render = function render(routeName, params, query) {
     if (!route)
         return (null);
 
-    var _url = route.spec.path.replace(/\/:([^/]+)/g, pathItem);
+    var _url = route.spec.path.replace(/\/:([A-Za-z0-9_]+)(\([^\)]+\))?/g, pathItem);
     var items = Object.keys(query || {}).map(queryItem);
     var queryString = items.length > 0 ? ('?' + items.join('&')) : '';
-
     return (_url + queryString);
 };
 

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -68,6 +68,23 @@ test('render route (special charaters)', function (t) {
     t.end();
 });
 
+test('render route (with sub-regex param)', function (t) {
+
+    var server = restify.createServer();
+    server.get({name: 'my-route', path: '/countries/:code([A-Z]{2,3})'}, mockResponse);
+
+    var link = server.router.render('my-route', {code: 'FR'});
+    t.equal(link, '/countries/FR');
+    
+    try {
+        link = server.router.render('my-route', {code: '111'});
+        t.fail("RegExp not used")
+    } catch (ex) {
+        t.equal(ex, 'Error: Route <cities> is missing parameter <state>');
+    }
+    t.end();
+});
+
 test('render route (with encode)', function (t) {
 
     var server = restify.createServer();

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -76,12 +76,8 @@ test('render route (with sub-regex param)', function (t) {
     var link = server.router.render('my-route', {code: 'FR'});
     t.equal(link, '/countries/FR');
     
-    try {
-        link = server.router.render('my-route', {code: '111'});
-        t.fail("RegExp should fail");
-    } catch (ex) {
-        t.equal(ex, 'Error: Unvalid value <111> for key <code>. Regular expression not matched');
-    }
+    link = server.router.render('my-route', {code: '111'});
+    t.equal(link, '/countries/111');
     t.end();
 });
 

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -81,6 +81,19 @@ test('render route (with sub-regex param)', function (t) {
     t.end();
 });
 
+test('render route (with nested sub-regex param)', function (t) {
+
+    var server = restify.createServer();
+    server.get({name: 'my-route', path: '/code/:code(([1-9][0-9]*)|([a-c]{2,3}))'}, mockResponse);
+
+    var link = server.router.render('my-route', {code: '123456789'});
+    t.equal(link, '/code/123456789');
+    
+    link = server.router.render('my-route', {code: 'aac'});
+    t.equal(link, '/code/aac');
+    t.end();
+});
+
 test('render route (with encode)', function (t) {
 
     var server = restify.createServer();

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -78,9 +78,9 @@ test('render route (with sub-regex param)', function (t) {
     
     try {
         link = server.router.render('my-route', {code: '111'});
-        t.fail("RegExp not used")
+        t.fail("RegExp should fail");
     } catch (ex) {
-        t.equal(ex, 'Error: Route <cities> is missing parameter <state>');
+        t.equal(ex, 'Error: Unvalid value <111> for key <code>. Regular expression not matched');
     }
     t.end();
 });

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1617,3 +1617,39 @@ test('explicitly sending a 403 on error', function (t) {
         t.end();
     });
 });
+
+test('Route with a valid RegExp params', function (t) {
+
+    SERVER.get({
+        name: 'regexp_param1',
+        path: '/foo/:id([0-9]+)'
+    }, function (req, res, next) {
+        t.equal(req.params.id, '0123456789');
+        res.send();
+        next();
+    });
+
+    CLIENT.get('/foo/0123456789', function (err, _, res) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+        t.end();
+    });
+});
+
+test('Route with an unvalid RegExp params', function (t) {
+
+    SERVER.get({
+        name: 'regexp_param2',
+        path: '/foo/:id([0-9]+)'
+    }, function (req, res, next) {
+        t.equal(req.params.id, 'A__M');
+        res.send();
+        next();
+    });
+
+    CLIENT.get('/foo/A__M', function (err, _, res) {
+        t.ok(err);
+        t.equal(res.statusCode, 404);
+        t.end();
+    });
+});


### PR DESCRIPTION
Hi,

Please find attached my first contribution on this project. This pull request allows partial regular expression for named parameters, like this : 
/foo/:bar([0-9]+) is parsed as :
req.params.bar = value that match the pattern.
In other case, route is considered as a "missing route".