### PR TITLE
Replace _headerSent with headersSent

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -104,7 +104,7 @@ function createServer(options) {
     server = new Server(opts);
     server.on('uncaughtException', function (req, res, route, e) {
         if (this.listeners('uncaughtException').length > 1 ||
-            res._headerSent) {
+            res.headersSent) {
             return (false);
         }
 


### PR DESCRIPTION
According to the documentation http://nodejs.org/api/http.html#http_response_headerssent, we can use `headersSent`.

I may be wrong on this one, but this just bit us in production where we had a custom `server.on('uncaughtException')` listener, and the `res._headerSent` were not working. Updating this to `headersSent` fixed the problem.

It looks to be available under node 0.10 only, if we want to maintain compatibility maybe we should use `|| res._headerSent || res.headersSent`.

I can't find any reference in the code where you set the `_headerSent` value, so I figured you were using a deprecated value from a low-level library.