### PR TITLE
Normalise route names when chaining routes

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -288,8 +288,9 @@ Router.prototype.get = function get(name, req, cb) {
     var route = false;
     var routes = this.routes[req.method] || [];
 
+    var routeName = name.replace(/\W/g, '').toLowerCase();
     for (var i = 0; i < routes.length; i++) {
-        if (routes[i].name === name) {
+        if (routes[i].name === routeName) {
             route = routes[i];
             try {
                 params = matchURL(route.path, req);

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1345,6 +1345,29 @@ test('gh-193 basic', function (t) {
     });
 });
 
+test('gh-193 route name normalization', function (t) {
+    SERVER.get({
+        name: 'foo',
+        path: '/foo'
+    }, function (req, res, next) {
+        next('b-a-r');
+    });
+
+    SERVER.get({
+        name: 'b-a-r',
+        path: '/bar'
+    }, function (req, res, next) {
+        res.send(200);
+        next();
+    });
+
+    CLIENT.get('/foo', function (err, _, res) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+        t.end();
+    });
+});
+
 
 test('gh-193 route ENOEXIST', function (t) {
     SERVER.get({


### PR DESCRIPTION
Route names appear to be normalised when they're added to the router but during route chaining the route name requested is used for the lookup verbatim.

This has the upshot that it is non-obvious how to chain to a route named `'test-route'`.