### PR TITLE
Enable {agent: false} option override per request

### DIFF
--- a/lib/clients/http_client.js
+++ b/lib/clients/http_client.js
@@ -514,7 +514,7 @@ HttpClient.prototype._options = function (method, options) {
 
     var self = this;
     var opts = {
-        agent: options.agent || self.agent,
+        agent: options.agent !== undefined ? options.agent : self.agent,
         ca: options.ca || self.ca,
         cert: options.cert || self.cert,
         ciphers: options.ciphers || self.ciphers,

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -528,7 +528,7 @@ test('POST raw', function (t) {
     });
 });
 
-test('Per request agent override', function(t) {
+test('PR-726 Enable {agent: false} option override per request', function(t) {
     var opts = {
         path: '/str/noagent',
         agent: false

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -528,6 +528,19 @@ test('POST raw', function (t) {
     });
 });
 
+test('Per request agent override', function(t) {
+    var opts = {
+        path: '/str/noagent',
+        agent: false
+    };
+    RAW_CLIENT.get(opts, function(err, req, res) {
+        t.ifError(err);
+        t.notStrictEqual(req.agent, RAW_CLIENT.agent, 'request should not use client agent');
+        console.log(res);
+        t.end();
+    });
+});
+
 test('GH-20 connectTimeout', function (t) {
     var client = restify.createClient({
         url: 'http://169.254.1.10',


### PR DESCRIPTION
Allow override of agent option to ```false``` for each request. 

Currently you can override an agent to true, or to an Agent object, but overriding to ```false``` will shortcut (via ```||```) to whatever the global setting is (```true```, ```false```, ```Agent```, or even ```undefined```).

In short, this pull request will make a per request ```false``` setting override the global setting.