### PR TITLE
Fix a bug when req.body === 'null'

### DIFF
--- a/lib/plugins/json_body_parser.js
+++ b/lib/plugins/json_body_parser.js
@@ -42,7 +42,7 @@ function jsonBodyParser(options) {
         if (options.mapParams !== false) {
             if (Array.isArray(params)) {
                 req.params = params;
-            } else if (typeof (params) === 'object') {
+            } else if (typeof (params) === 'object' && params !== null) {
                 Object.keys(params || {}).forEach(function (k) {
                     var p = req.params[k];
                     if (p && !override)

--- a/lib/plugins/json_body_parser.js
+++ b/lib/plugins/json_body_parser.js
@@ -43,7 +43,7 @@ function jsonBodyParser(options) {
             if (Array.isArray(params)) {
                 req.params = params;
             } else if (typeof (params) === 'object') {
-                Object.keys(params).forEach(function (k) {
+                Object.keys(params || {}).forEach(function (k) {
                     var p = req.params[k];
                     if (p && !override)
                         return (false);

--- a/lib/plugins/json_body_parser.js
+++ b/lib/plugins/json_body_parser.js
@@ -43,7 +43,7 @@ function jsonBodyParser(options) {
             if (Array.isArray(params)) {
                 req.params = params;
             } else if (typeof (params) === 'object' && params !== null) {
-                Object.keys(params || {}).forEach(function (k) {
+                Object.keys(params).forEach(function (k) {
                     var p = req.params[k];
                     if (p && !override)
                         return (false);
@@ -51,7 +51,7 @@ function jsonBodyParser(options) {
                     return (true);
                 });
             } else {
-                req.params = params;
+                req.params = params || req.params;
             }
         } else {
             req._body = req.body;

--- a/test/plugins.test.js
+++ b/test/plugins.test.js
@@ -396,6 +396,31 @@ test('body json ok (no params)', function (t) {
     });
 });
 
+test('body json ok (null params)', function (t) {
+    var STRING_CLIENT = restify.createStringClient({
+        url: 'http://127.0.0.1:' + PORT,
+        dtrace: helper.dtrace,
+        retry: false,
+        agent: false,
+        contentType: 'application/json',
+        accept: 'application/json'
+    });
+
+    SERVER.post('/body/:id',
+        restify.bodyParser(),
+        function (req, res, next) {
+            t.equal(req.params.id, 'foo');
+            t.equal(req.params.name, 'markc');
+            res.send();
+            next();
+        });
+
+    STRING_CLIENT.post('/body/foo?name=markc', 'null', function (err, _, res) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+        t.end();
+    });
+});
 
 test('GH-318 get request with body (default)', function (t) {
     SERVER.get('/getWithoutBody',


### PR DESCRIPTION
With req.body === 'null', we have an error : Object.keys called on non-object.
Thanks to some investigations we found that params is null and in Javascript typeof null === 'object'.