### PR TITLE
Added typeof check to the jsonp callback

### DIFF
--- a/lib/formatters/jsonp.js
+++ b/lib/formatters/jsonp.js
@@ -25,7 +25,7 @@ function formatJSONP(req, res, body) {
     var cb = req.query.callback || req.query.jsonp;
     var data;
     if (cb) {
-        data = cb + '(' + JSON.stringify(body) + ');';
+        data = 'typeof ' + cb + ' === \'function\' && ' + cb + '(' + JSON.stringify(body) + ');';
     } else {
         data = JSON.stringify(body);
     }

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -100,6 +100,7 @@ before(function (callback) {
         });
 
         SERVER.use(restify.acceptParser(['json', 'text/plain']));
+        SERVER.use(restify.jsonp()); // Added for GH-729
         SERVER.use(restify.dateParser());
         SERVER.use(restify.authorizationParser());
         SERVER.use(restify.queryParser());
@@ -202,6 +203,17 @@ test('GH-388 GET json, but really HTML', function (t) {
         t.ok(req);
         t.ok(res);
         t.deepEqual(obj, {});
+        t.end();
+    });
+});
+
+
+test('GH-729 GET jsonp', function (t) {
+    JSON_CLIENT.get('/json/jsonp?callback=testCallback', function (err, req, res) {
+        t.ifError(err);
+        t.ok(req);
+        t.ok(res);
+        t.equal(res.body, 'typeof testCallback === \'function\' && testCallback({"hello":"jsonp"});');
         t.end();
     });
 });


### PR DESCRIPTION
When getting data via a jsonp request, its useful to have a check that ensures the callback function is defined before calling it. This prevents a reference error from being thrown in the browser if a function name is not defined when data is returned.