### PR TITLE
Add ability to listen for error events

### DIFF
--- a/docs/index.restdown
+++ b/docs/index.restdown
@@ -473,6 +473,23 @@ Alternatively, restify 2.1 supports a `next.ifError` API:
       });
     });
 
+Sometimes, for all requests, you may want to handle an error condition the same
+way. As an example, you may want to serve a 500 page on all
+`InternalServerErrors`. In this case you can add a listener for this error that
+is always fired when this Error is encountered by Restify as part of a
+`next(error)` statement. This gives you a way to handle all errors of the same
+class identically across the server.
+
+    server.get('/hello/:name', function(req, res, next) {
+      // some internal unrecoverable error
+      var err = new restify.errors.InternalServerError('oh noes!');
+      return next(err);
+    });
+
+    server.on('InternalServerError', function (req, res, err, cb) {
+      err._customContent = 'something is wrong!';
+      return cb();
+    });
 
 ### HttpError
 
@@ -1003,8 +1020,8 @@ is expected that you are going to map it to a route, as below:
       default: 'index.html'
     }));
 
-The above `route` and `directory` combination will serve a file located in  
-`./documentation/v1/docs/current/index.html` when you attempt to hit 
+The above `route` and `directory` combination will serve a file located in
+`./documentation/v1/docs/current/index.html` when you attempt to hit
 `http://localhost:8080/docs/current/`.
 
 The plugin will enforce that all files under `directory` are served. The

--- a/lib/server.js
+++ b/lib/server.js
@@ -142,6 +142,8 @@ function emitRouteError(server, req, res, err) {
     } else {
         name = err.name.replace(/Error$/, '');
     }
+
+    req.log.trace({name: name, err: err}, 'entering emitRouteError');
     if (server.listeners(name).length > 0) {
         server.emit(name, req, res, once(function () {
             server.emit('after', req, res, null);
@@ -647,14 +649,27 @@ Server.prototype._run = function _run(req, res, route, chain, cb) {
     var log = this.log;
     var self = this;
     var t;
+    var errName;
+    var emittedError = false;
+    if (cb)
+        cb = once(cb);
 
     function next(arg) {
         var done = false;
         if (arg) {
             if (arg instanceof Error) {
-                log.trace({err: arg}, 'next(err=%s)',
+                errName = arg.name.replace(/Error$/, '');
+                log.trace({err: arg, errName: errName}, 'next(err=%s)',
                     (arg.name || 'Error'));
-                res.send(arg);
+                if (self.listeners(errName).length > 0) {
+                    self.emit(errName, req, res, arg, once(function () {
+                        res.send(arg);
+                        return (cb ? cb(arg) : true);
+                    }));
+                    emittedError = true;
+                } else {
+                    res.send(arg);
+                }
                 done = true;
             } else if (typeof (arg) === 'string') {
                 if (req._rstfy_chained_route) {
@@ -746,7 +761,13 @@ Server.prototype._run = function _run(req, res, route, chain, cb) {
             self.emit('done', req, res, route);
         }
 
-        return (cb ? cb(arg) : true);
+        // don't return cb here if we emit an error since we will cb after the
+        // handler fires.
+        if (!emittedError) {
+            return (cb ? cb(arg) : true);
+        } else {
+            return (true);
+        }
     }
 
     var n1 = once(next);

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1645,3 +1645,25 @@ test('explicitly sending a 403 on error', function (t) {
         t.end();
     });
 });
+
+
+test('fire event on error', function (t) {
+    SERVER.once('InternalServer', function (req, res, err, cb) {
+        t.ok(req);
+        t.ok(res);
+        t.ok(err);
+        t.ok(cb);
+        return (cb());
+    });
+
+    SERVER.get('/', function (req, res, next) {
+        return (next(new restify.errors.InternalServerError('bah!')));
+    });
+
+    CLIENT.get('/', function (err, _, res) {
+        t.ok(err);
+        t.equal(res.statusCode, 500);
+        t.expect(6);
+        t.end();
+    });
+});


### PR DESCRIPTION
This is especially helpful for server 5XX or 4XX error pages. You can listen for say, `InternalServerError`, and then decorate that error with information globally, without having to do that every time the error is served.