### PR TITLE
Fix issue #691

### DIFF
--- a/lib/plugins/fielded_text_body_parser.js
+++ b/lib/plugins/fielded_text_body_parser.js
@@ -46,36 +46,28 @@ function fieldedTextParser(options) {
         var quote = (hQuote) ? hQuote : '"';
         var columns = (hColumns) ? hColumns : true;
 
-        var parsedBody = [];
+        var parserOptions = {
+            delimiter: delimiter,
+            quote: quote,
+            escape: escape,
+            columns: columns
+        };
 
-        csv()
-            .from(req.body, {
-                delimiter: delimiter,
-                quote: quote,
-                escape: escape,
-                columns: columns
-            })
-            .on('record', function (row, index) {
+        csv.parse(req.body, parserOptions, function (err, parsedBody) {
+            if (err) {
+                return (next(err));
+            }
+            // Add an "index" property to every row
+            parsedBody.forEach(function (row, index) {
                 row.index = index;
-                parsedBody.push(row);
-            })
-            .on('end', function (count) {
-                req.body = parsedBody;
-                return (next());
-            })
-            .on('error', function (error) {
-                return (next(error));
             });
+            req.body = parsedBody;
+            return (next());
+        });
 
     }
 
-    var chain = [];
-    if (!options.bodyReader) {
-        chain.push(bodyReader(options));
-    }
-    chain.push(parseFieldedText);
-
-    return (chain);
+    return (parseFieldedText);
 
 }
 

--- a/test/fieldedTextParser.test.js
+++ b/test/fieldedTextParser.test.js
@@ -82,15 +82,9 @@ test('Parse CSV body', function (t) {
         }
     };
     CLIENT.post(options, function (err, req) {
-        if (err) {
-            t.end(err);
-            return;
-        }
+        t.ifError(err);
         req.on('result', function (errReq, res) {
-            if (errReq) {
-                t.end(errReq);
-                return;
-            }
+            t.ifError(errReq);
             res.body = '';
             res.setEncoding('utf8');
             res.on('data', function (chunk) {
@@ -117,15 +111,9 @@ test('Parse TSV body', function (t) {
         }
     };
     CLIENT.post(options, function (err, req) {
-        if (err) {
-            t.end(err);
-            return;
-        }
+        t.ifError(err);
         req.on('result', function (errReq, res) {
-            if (errReq) {
-                t.end(errReq);
-                return;
-            }
+            t.ifError(errReq);
             res.body = '';
             res.setEncoding('utf8');
             res.on('data', function (chunk) {


### PR DESCRIPTION
Body parser expects this function to return a handler function, rather than an array of handlers.  Currently, requests with `Content-Type: text/csv` will crash the server unless there is a handler for uncaught exceptions.