### PR TITLE
add missing fn invocation in req.absoluteUri

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -47,7 +47,7 @@ Request.prototype.absoluteUri = function absoluteUri(path) {
 
     var protocol = this.secure ? 'https://' : 'http://';
     var hostname = this.headers['host'];
-    return (url.resolve(protocol + hostname + this.path + '/', path));
+    return (url.resolve(protocol + hostname + this.path() + '/', path));
 };
 
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1686,3 +1686,20 @@ test('fire event on error', function (t) {
         t.end();
     });
 });
+
+test('gh-757 req.absoluteUri() defaults path segment to req.path()', function (t) {
+    SERVER.get('/the-original-path', function (req, res, next) {
+        var prefix = 'http://127.0.0.1:' + PORT;
+        t.equal(req.absoluteUri('?key=value'), prefix + '/the-original-path/?key=value');
+        t.equal(req.absoluteUri('#fragment'), prefix + '/the-original-path/#fragment');
+        t.equal(req.absoluteUri('?key=value#fragment'), prefix + '/the-original-path/?key=value#fragment');
+        res.send();
+        next();
+    });
+
+    CLIENT.get('/the-original-path', function (err, _, res) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+        t.end();
+    });
+});


### PR DESCRIPTION
When `req.path()` was [made into a function](https://github.com/mcavage/node-restify/wiki/1.4-to-2.0-Migration-Tips#reqpath---reqpath-or-reqgetpath), `req.absoluteUri(path)` wasn't updated to invoke it. Currently, it serializes the JavaScript implementation of `req.path()` if the `path` argument to `req.absoluteUri(path)` doesn't include a path component (e.g. it's a query or a fragment).

e.g.

```
Link: <http://localhost/:8000function%20getPath()%20{%0A%20%20%20%20%20%20%20%20if%20(this._path%20!==%20undefined)%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%20(this._path);%0A%0A%20%20%20%20%20%20%20%20this._path%20=%20this.getUrl().pathname;%0A%20%20%20%20%20%20%20%20return%20(this._path);%0A}/?after=502b0dee92169e6654000074>; rel="next"
```