### PR TITLE
Prefer the existing 'err' serializer for audit logging

### DIFF
--- a/lib/plugins/audit.js
+++ b/lib/plugins/audit.js
@@ -26,7 +26,7 @@ function auditLogger(options) {
     var log = options.log.child({
         audit: true,
         serializers: {
-            err: bunyan.stdSerializers.err,
+            err: options.log.serializers.err || bunyan.stdSerializers.err,
             req: function auditRequestSerializer(req) {
                 if (!req)
                     return (false);


### PR DESCRIPTION
This allows an app to have a custom err serializer (e.g.
one that adds extra fields from the error object) and
have the audit logs use it.