### PR TITLE
Content-Type in route not matching client Accept; 406

### DIFF
--- a/test/formatter.test.js
+++ b/test/formatter.test.js
@@ -113,3 +113,23 @@ test('q-val priority', function (t) {
         t.end();
     });
 });
+
+test('Content-Type in route not matching client Accept sends 406', function (t) {
+    var opts = {
+        path: '/tmp2',
+        headers: {
+            accept: 'application/foo'
+        }
+    };
+
+    SERVER.get('/tmp2', function (req, res) {
+        res.header('Content-Type', 'text/plain');
+        res.send('dummy response');
+    });
+
+
+    CLIENT.get(opts, function (err, req, res, data) {
+        t.equal(res.statusCode, 406);
+        t.end();
+    });
+});

--- a/test/formatter.test.js
+++ b/test/formatter.test.js
@@ -114,7 +114,7 @@ test('q-val priority', function (t) {
     });
 });
 
-test('Content-Type in route not matching client Accept sends 406', function (t) {
+test('Content-Type in route not matching client Accept; 406', function (t) {
     var opts = {
         path: '/tmp2',
         headers: {


### PR DESCRIPTION
When you set the content-type header in a route, and the client never sent an accept for that type, the server should send 406 just as if the server didn't support any accepts in server.acceptable

Currently the result is `Content-Type` being set to `text/plain` and the output of that formatter is sent.