### PR TITLE
Update index.restdown for Server API error event listener examples

### DIFF
--- a/docs/index.restdown
+++ b/docs/index.restdown
@@ -698,7 +698,7 @@ and has several other events you want to listen on.
 
 ##### Event: 'NotFound'
 
-`function (request, response, cb) {}`
+`function (request, response, error, cb) {}`
 
 When a client request is sent for a URL that does not exist, restify
 will emit this event. Note that restify checks for listeners on this
@@ -707,7 +707,7 @@ is expected that if you listen for this event, you respond to the client.
 
 #### Event: 'MethodNotAllowed'
 
-`function (request, response, cb) {}`
+`function (request, response, error, cb) {}`
 
 When a client request is sent for a URL that does exist, but you have
 not registered a route for that HTTP verb, restify will emit this
@@ -717,7 +717,7 @@ is expected that if you listen for this event, you respond to the client.
 
 #### Event: 'VersionNotAllowed'
 
-`function (request, response, cb) {}`
+`function (request, response, error, cb) {}`
 
 When a client request is sent for a route that exists, but does not
 match the version(s) on those routes, restify will emit this
@@ -727,7 +727,7 @@ is expected that if you listen for this event, you respond to the client.
 
 #### Event: UnsupportedMediaType'
 
-`function (request, response, cb) {}`
+`function (request, response, error, cb) {}`
 
 When a client request is sent for a route that exist, but has a `content-type`
 mismatch, restify will emit this event. Note that restify checks for listeners


### PR DESCRIPTION
Server API event listener examples were missing error param, causing cb to be in wrong position. I believe the docs became outdated on commit ab1a7522af51a4337468f06cf4b929b05fba458f