### PR TITLE
Rectify jsstylechk errors, remove unused vars in server+router

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -5,7 +5,6 @@ var url = require('url');
 var util = require('util');
 
 var assert = require('assert-plus');
-var deepEqual = require('deep-equal');
 var LRU = require('lru-cache');
 var Negotiator = require('negotiator');
 var semver = require('semver');
@@ -19,8 +18,6 @@ var utils = require('./utils');
 
 var DEF_CT = 'application/octet-stream';
 
-var maxSatisfying = semver.maxSatisfying;
-
 var BadRequestError = errors.BadRequestError;
 var InternalError = errors.InternalError;
 var InvalidArgumentError = errors.InvalidArgumentError;
@@ -33,14 +30,6 @@ var shallowCopy = utils.shallowCopy;
 
 
 ///--- Helpers
-
-function createCachedRoute(o, path, version, route) {
-    if (!o.hasOwnProperty(path))
-        o[path] = {};
-
-    if (!o[path].hasOwnProperty(version))
-        o[path][version] = route;
-}
 
 
 function matchURL(re, req) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -4,7 +4,6 @@ var domain = require('domain');
 var EventEmitter = require('events').EventEmitter;
 var http = require('http');
 var https = require('https');
-var url = require('url');
 var util = require('util');
 
 var assert = require('assert-plus');
@@ -31,8 +30,6 @@ require('./response');
 
 var sprintf = util.format;
 
-var BadMethodError = errors.BadMethodError;
-var InvalidVersionError = errors.InvalidVersionError;
 var ResourceNotFoundError = errors.ResourceNotFoundError;
 
 var PROXY_EVENTS = [
@@ -251,7 +248,7 @@ function Server(options) {
 
     this.server.on('request', function onRequest(req, res) {
         self.emit('request', req, res);
-        if ( options.socketio && /^\/socket\.io.*/.test(req.url))
+        if (options.socketio && (/^\/socket\.io.*/).test(req.url))
              return;
 
         self._setupRequest(req, res);


### PR DESCRIPTION
I was pulling `compileURL` out of *lib/router.js* into a separate module and noticed that *lib/router.js* had variables declared that weren't ever used. Upon further inspection, I found this to be the case in *lib/server.js* as well. 

Unused variables make code harder to read. They create an inaccurate overview of the file at hand.

I've:
* Removed the unused variables in *lib/router.js*
* Removed the unused variables in *lib/server.js*
* Rectified the stylistic discrepancies on line 254 of *lib/server.js* that were causing tests to fail on Node.js v0.12.2 (`make: *** [lib/server.js.jsstylechk] Error 1`)