### PR TITLE
Allow 0, false, and null as json body #686

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -227,7 +227,7 @@ Response.prototype.send = function send(code, body, headers) {
             log.trace({res: self}, 'response sent');
     }
 
-    if (body) {
+    if (body !== undefined) {
         var ret = this.format(body, _cb);
         if (!(ret instanceof Response)) {
             _cb(null, ret);


### PR DESCRIPTION
0, false, and null are all valid body contents of a request, however currently only an empty body is returned in these cases.

For Example:
response.json(200, true);
- currently returns:
200 OK
true

- however false doesn't return a body:
response.json(200, false);
200 OK


Change allows false to also return:
response.json(200, false);
200 OK
false