### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "nodeunit": "^0.9.0",
     "watershed": "^0.3.0"
   },
+  "license": "MIT",
   "scripts": {
     "test": "make prepush"
   }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/