### PR TITLE
Removed regexp for socket.io check

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -258,7 +258,7 @@ function Server(options) {
     this.server.on('request', function onRequest(req, res) {
         self.emit('request', req, res);
 
-        if (options.socketio && (/^\/socket\.io.*/).test(req.url)) {
+        if (options.socketio && req.url.indexOf('/socket.io') === 0) {
             return;
         }
 


### PR DESCRIPTION
Actually this check is still not fully cover `socket.io` usage. I mean `/socket.io` prefix could be redefined.